### PR TITLE
Add ADC export and diagnostics to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,13 +203,13 @@ jobs:
         run: |
           set -euo pipefail
           BASE="${SERVICE_URL%/}"
-          # 清掉可能殘留的 impersonation 設定
+          # 防呆：確保沒有殘留 impersonation
           gcloud config unset auth/impersonate_service_account || true
           echo "Active account:"; gcloud auth list --filter=status:ACTIVE
           echo "ADC file: ${GOOGLE_APPLICATION_CREDENTIALS:-<none>}"
           gcloud --version
-          # 關鍵：audience 必須是 Cloud Run 服務的根 URL（不含路徑）
-          IDT="$(gcloud auth print-identity-token --include-email --audiences="$BASE")"
+          # 以 ADC 產生 Cloud Run 需要的 ID Token（audience=服務根網址）
+          IDT="$(gcloud auth application-default print-identity-token --audiences="$BASE")"
           echo "id_token=$IDT" >> "$GITHUB_OUTPUT"
 
       - name: Probe Cloud Run /health (no impersonation)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
     env:
       PROJECT_ID: esp32cam-472912
       REGION: asia-east1
-
       SERVICE_URL: ${{ vars.SERVICE_URL }}
       PIPELINE_ROOT: ${{ vars.PIPELINE_ROOT }}
       GCS_INBOX: ${{ vars.GCS_INBOX }}
@@ -203,13 +202,17 @@ jobs:
         run: |
           set -euo pipefail
           BASE="${SERVICE_URL%/}"
-          # 防呆：確保沒有殘留 impersonation
+          # 清掉可能殘留的 impersonation 設定
           gcloud config unset auth/impersonate_service_account || true
           echo "Active account:"; gcloud auth list --filter=status:ACTIVE
           echo "ADC file: ${GOOGLE_APPLICATION_CREDENTIALS:-<none>}"
           gcloud --version
-          # 以 ADC 產生 Cloud Run 需要的 ID Token（audience=服務根網址）
-          IDT="$(gcloud auth application-default print-identity-token --audiences="$BASE")"
+          # 先用 ADC 取 ID Token；若該子命令不存在或失敗，改用 google-auth 備援
+          if IDT="$(gcloud auth application-default print-identity-token --audiences="$BASE" 2>/dev/null)"; then
+            :
+          else
+            IDT="$(python3 -c 'import os; from google.auth.transport.requests import Request; from google.oauth2.id_token import fetch_id_token; aud=os.environ["BASE"]; print(fetch_id_token(Request(), aud))')"
+          fi
           echo "id_token=$IDT" >> "$GITHUB_OUTPUT"
 
       - name: Probe Cloud Run /health (no impersonation)
@@ -242,13 +245,10 @@ jobs:
               gcloud info || true
               gcloud config list || true
               python3 - <<'PY'
-              import os,sys,jwt
-              import base64,json
-              tok=os.environ.get("IDT")
-              h=jwt.get_unverified_header(tok)
-              p=jwt.decode(tok, options={"verify_signature":False})
-              print("IDT.header=",h)
-              print("IDT.payload=",json.dumps(p,indent=2))
+                import os,sys,jwt,base64,json
+                tok=os.environ.get("IDT")
+                h=jwt.get_unverified_header(tok); p=jwt.decode(tok, options={"verify_signature":False})
+                print("IDT.header=",h); print("IDT.payload=",json.dumps(p,indent=2))
               PY
               exit 1
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - develop
       - test
       - 'feature/**'
+      - 'codex/**'
   pull_request: {}
   workflow_dispatch: {}
 
@@ -97,6 +98,13 @@ jobs:
           service_account: ${{ secrets.GCP_SA_EMAIL }}
           create_credentials_file: true
           export_environment_variables: true
+
+      - name: Export ADC env
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${{ steps.gcp-auth.outputs.credentials_file_path }}" >> "$GITHUB_ENV"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=${{ steps.gcp-auth.outputs.credentials_file_path }}" >> "$GITHUB_ENV"
 
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
@@ -189,19 +197,23 @@ jobs:
             echo "::notice::No 'pipeline-jobs wait' available; continuing."
           fi
 
-      - name: Fetch ID token for Cloud Run (via auth action)
+      - name: Get Cloud Run ID token (gcloud, no impersonation)
         id: idt
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-          token_format: 'id_token'
-          audience: ${{ env.SERVICE_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE="${SERVICE_URL%/}"
+          # 清掉可能殘留的 impersonation 設定
+          gcloud config unset auth/impersonate_service_account || true
+          echo "Active account:"; gcloud auth list --filter=status:ACTIVE
+          echo "ADC file: ${GOOGLE_APPLICATION_CREDENTIALS:-<none>}"
+          gcloud --version
+          # 關鍵：audience 必須是 Cloud Run 服務的根 URL（不含路徑）
+          IDT="$(gcloud auth print-identity-token --include-email --audiences="$BASE")"
+          echo "id_token=$IDT" >> "$GITHUB_OUTPUT"
 
       - name: Probe Cloud Run /health (no impersonation)
         shell: bash
-        env:
-          IDT: ${{ steps.idt.outputs.id_token }}
         run: |
           set -euo pipefail
           URL="${SERVICE_URL%/}${CLOUD_RUN_HEALTH_PATH:-/health}"
@@ -217,13 +229,29 @@ jobs:
           echo "GET (auth) $URL"
           n=0
           while :; do
-            HTTP2=$(curl -sS -H "Authorization: Bearer ${IDT}" -o /tmp/health_auth.out -w "%{http_code}" "$URL" || true)
+            HTTP2=$(curl -sS -H "Authorization: Bearer ${{ steps.idt.outputs.id_token }}" -o /tmp/health_auth.out -w "%{http_code}" "$URL" || true)
             echo "HTTP(auth)=$HTTP2"
             if [ "$HTTP2" -ge 200 ] && [ "$HTTP2" -lt 300 ]; then
               echo "---- body(auth) ----"; cat /tmp/health_auth.out || true; echo "--------------------"
               break
             fi
-            n=$((n+1)); [ $n -ge 5 ] && { echo "Health check failed after retries"; exit 1; }
+            n=$((n+1))
+            if [ $n -ge 5 ]; then
+              echo "Health check failed after retries; collecting diagnostics"
+              export IDT="${{ steps.idt.outputs.id_token }}"
+              gcloud info || true
+              gcloud config list || true
+              python3 - <<'PY'
+              import os,sys,jwt
+              import base64,json
+              tok=os.environ.get("IDT")
+              h=jwt.get_unverified_header(tok)
+              p=jwt.decode(tok, options={"verify_signature":False})
+              print("IDT.header=",h)
+              print("IDT.payload=",json.dumps(p,indent=2))
+              PY
+              exit 1
+            fi
             sleep 3
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,11 +207,13 @@ jobs:
           echo "Active account:"; gcloud auth list --filter=status:ACTIVE
           echo "ADC file: ${GOOGLE_APPLICATION_CREDENTIALS:-<none>}"
           gcloud --version
+
           # 先用 ADC 取 ID Token；若該子命令不存在或失敗，改用 google-auth 備援
           if IDT="$(gcloud auth application-default print-identity-token --audiences="$BASE" 2>/dev/null)"; then
             :
           else
-            IDT="$(python3 -c 'import os; from google.auth.transport.requests import Request; from google.oauth2.id_token import fetch_id_token; aud=os.environ["BASE"]; print(fetch_id_token(Request(), aud))')"
+            python3 -m pip install --quiet --upgrade google-auth
+            IDT="$(BASE="$BASE" python3 -c 'from google.auth.transport.requests import Request; from google.oauth2.id_token import fetch_id_token; import os; aud = os.environ["BASE"]; print(fetch_id_token(Request(), aud))')"
           fi
           echo "id_token=$IDT" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,13 +208,27 @@ jobs:
           echo "ADC file: ${GOOGLE_APPLICATION_CREDENTIALS:-<none>}"
           gcloud --version
 
-          # 先用 ADC 取 ID Token；若該子命令不存在或失敗，改用 google-auth 備援
+          # 先用 gcloud（ADC）取；若該子命令不存在或失敗，改用 google-auth 備援
           if IDT="$(gcloud auth application-default print-identity-token --audiences="$BASE" 2>/dev/null)"; then
             :
           else
             python3 -m pip install --quiet --upgrade google-auth
-            IDT="$(BASE="$BASE" python3 -c 'from google.auth.transport.requests import Request; from google.oauth2.id_token import fetch_id_token; import os; aud = os.environ["BASE"]; print(fetch_id_token(Request(), aud))')"
+            IDT="$(BASE="$BASE" ADC="$GOOGLE_APPLICATION_CREDENTIALS" python3 - <<'PY'
+              from google.auth.transport.requests import Request
+              from google.auth import load_credentials_from_file
+              from google.oauth2 import id_token
+              import os
+
+              aud = os.environ["BASE"]
+              adc = os.environ["ADC"]  # 指向 gha-creds-*.json（external_account）
+              creds, _ = load_credentials_from_file(adc)  # 明確載入 ADC（支援 WIF/external_account）
+              tok = id_token.IDTokenCredentials.from_credentials(creds, target_audience=aud)
+              tok.refresh(Request())
+              print(tok.token)
+            PY
+            )"
           fi
+
           echo "id_token=$IDT" >> "$GITHUB_OUTPUT"
 
       - name: Probe Cloud Run /health (no impersonation)

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -20,12 +20,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          export_environment_variables: true
+
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
 
       - name: Deploy (source-based)
         run: |

--- a/.github/workflows/pipeline-check.yml
+++ b/.github/workflows/pipeline-check.yml
@@ -146,13 +146,27 @@ jobs:
           echo "ADC file: ${GOOGLE_APPLICATION_CREDENTIALS:-<none>}"
           gcloud --version
 
-          # 先用 ADC 取 ID Token；若該子命令不存在或失敗，改用 google-auth 備援
+          # 先用 gcloud（ADC）取；若該子命令不存在或失敗，改用 google-auth 備援
           if IDT="$(gcloud auth application-default print-identity-token --audiences="$BASE" 2>/dev/null)"; then
             :
           else
             python3 -m pip install --quiet --upgrade google-auth
-            IDT="$(BASE="$BASE" python3 -c 'from google.auth.transport.requests import Request; from google.oauth2.id_token import fetch_id_token; import os; aud = os.environ["BASE"]; print(fetch_id_token(Request(), aud))')"
+            IDT="$(BASE="$BASE" ADC="$GOOGLE_APPLICATION_CREDENTIALS" python3 - <<'PY'
+              from google.auth.transport.requests import Request
+              from google.auth import load_credentials_from_file
+              from google.oauth2 import id_token
+              import os
+
+              aud = os.environ["BASE"]
+              adc = os.environ["ADC"]  # 指向 gha-creds-*.json（external_account）
+              creds, _ = load_credentials_from_file(adc)  # 明確載入 ADC（支援 WIF/external_account）
+              tok = id_token.IDTokenCredentials.from_credentials(creds, target_audience=aud)
+              tok.refresh(Request())
+              print(tok.token)
+            PY
+            )"
           fi
+
           echo "id_token=$IDT" >> "$GITHUB_OUTPUT"
 
       - name: Probe Cloud Run /health (no impersonation)

--- a/.github/workflows/pipeline-check.yml
+++ b/.github/workflows/pipeline-check.yml
@@ -140,13 +140,16 @@ jobs:
         run: |
           set -euo pipefail
           BASE="${SERVICE_URL%/}"
-          # 防呆：確保沒有殘留 impersonation
+          # 清掉可能殘留的 impersonation 設定
           gcloud config unset auth/impersonate_service_account || true
           echo "Active account:"; gcloud auth list --filter=status:ACTIVE
           echo "ADC file: ${GOOGLE_APPLICATION_CREDENTIALS:-<none>}"
           gcloud --version
-          # 以 ADC 產生 Cloud Run 需要的 ID Token（audience=服務根網址）
-          IDT="$(gcloud auth application-default print-identity-token --audiences="$BASE")"
+          if IDT="$(gcloud auth application-default print-identity-token --audiences="$BASE" 2>/dev/null)"; then
+            :
+          else
+            IDT="$(python3 -c 'import os; from google.auth.transport.requests import Request; from google.oauth2.id_token import fetch_id_token; aud=os.environ["BASE"]; print(fetch_id_token(Request(), aud))')"
+          fi
           echo "id_token=$IDT" >> "$GITHUB_OUTPUT"
 
       - name: Probe Cloud Run /health (no impersonation)
@@ -178,15 +181,12 @@ jobs:
               export IDT="${{ steps.idt.outputs.id_token }}"
               gcloud info || true
               gcloud config list || true
-            python3 - <<'PY'
-            import os,sys,jwt
-            import base64,json
-            tok=os.environ.get("IDT")
-            h=jwt.get_unverified_header(tok)
-            p=jwt.decode(tok, options={"verify_signature":False})
-            print("IDT.header=",h)
-            print("IDT.payload=",json.dumps(p,indent=2))
-            PY
+              python3 - <<'PY'
+                import os,sys,jwt,base64,json
+                tok=os.environ.get("IDT")
+                h=jwt.get_unverified_header(tok); p=jwt.decode(tok, options={"verify_signature":False})
+                print("IDT.header=",h); print("IDT.payload=",json.dumps(p,indent=2))
+              PY
               exit 1
             fi
             sleep 3

--- a/.github/workflows/pipeline-check.yml
+++ b/.github/workflows/pipeline-check.yml
@@ -140,13 +140,13 @@ jobs:
         run: |
           set -euo pipefail
           BASE="${SERVICE_URL%/}"
-          # 清掉可能殘留的 impersonation 設定
+          # 防呆：確保沒有殘留 impersonation
           gcloud config unset auth/impersonate_service_account || true
           echo "Active account:"; gcloud auth list --filter=status:ACTIVE
           echo "ADC file: ${GOOGLE_APPLICATION_CREDENTIALS:-<none>}"
           gcloud --version
-          # 關鍵：audience 必須是 Cloud Run 服務的根 URL（不含路徑）
-          IDT="$(gcloud auth print-identity-token --include-email --audiences="$BASE")"
+          # 以 ADC 產生 Cloud Run 需要的 ID Token（audience=服務根網址）
+          IDT="$(gcloud auth application-default print-identity-token --audiences="$BASE")"
           echo "id_token=$IDT" >> "$GITHUB_OUTPUT"
 
       - name: Probe Cloud Run /health (no impersonation)

--- a/.github/workflows/pipeline-check.yml
+++ b/.github/workflows/pipeline-check.yml
@@ -35,6 +35,13 @@ jobs:
           create_credentials_file: true
           export_environment_variables: true
 
+      - name: Export ADC env
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${{ steps.gcp-auth.outputs.credentials_file_path }}" >> "$GITHUB_ENV"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=${{ steps.gcp-auth.outputs.credentials_file_path }}" >> "$GITHUB_ENV"
+
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
         with:
@@ -127,19 +134,23 @@ jobs:
             echo "::notice::No 'pipeline-jobs wait' available; continuing."
           fi
 
-      - name: Fetch ID token for Cloud Run (via auth action)
+      - name: Get Cloud Run ID token (gcloud, no impersonation)
         id: idt
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-          token_format: 'id_token'
-          audience: ${{ env.SERVICE_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE="${SERVICE_URL%/}"
+          # 清掉可能殘留的 impersonation 設定
+          gcloud config unset auth/impersonate_service_account || true
+          echo "Active account:"; gcloud auth list --filter=status:ACTIVE
+          echo "ADC file: ${GOOGLE_APPLICATION_CREDENTIALS:-<none>}"
+          gcloud --version
+          # 關鍵：audience 必須是 Cloud Run 服務的根 URL（不含路徑）
+          IDT="$(gcloud auth print-identity-token --include-email --audiences="$BASE")"
+          echo "id_token=$IDT" >> "$GITHUB_OUTPUT"
 
       - name: Probe Cloud Run /health (no impersonation)
         shell: bash
-        env:
-          IDT: ${{ steps.idt.outputs.id_token }}
         run: |
           set -euo pipefail
           URL="${SERVICE_URL%/}${CLOUD_RUN_HEALTH_PATH:-/health}"
@@ -155,13 +166,29 @@ jobs:
           echo "GET (auth) $URL"
           n=0
           while :; do
-            HTTP2=$(curl -sS -H "Authorization: Bearer ${IDT}" -o /tmp/health_auth.out -w "%{http_code}" "$URL" || true)
+            HTTP2=$(curl -sS -H "Authorization: Bearer ${{ steps.idt.outputs.id_token }}" -o /tmp/health_auth.out -w "%{http_code}" "$URL" || true)
             echo "HTTP(auth)=$HTTP2"
             if [ "$HTTP2" -ge 200 ] && [ "$HTTP2" -lt 300 ]; then
               echo "---- body(auth) ----"; cat /tmp/health_auth.out || true; echo "--------------------"
               break
             fi
-            n=$((n+1)); [ $n -ge 5 ] && { echo "Health check failed after retries"; exit 1; }
+            n=$((n+1))
+            if [ $n -ge 5 ]; then
+              echo "Health check failed after retries; collecting diagnostics"
+              export IDT="${{ steps.idt.outputs.id_token }}"
+              gcloud info || true
+              gcloud config list || true
+            python3 - <<'PY'
+            import os,sys,jwt
+            import base64,json
+            tok=os.environ.get("IDT")
+            h=jwt.get_unverified_header(tok)
+            p=jwt.decode(tok, options={"verify_signature":False})
+            print("IDT.header=",h)
+            print("IDT.payload=",json.dumps(p,indent=2))
+            PY
+              exit 1
+            fi
             sleep 3
           done
 

--- a/.github/workflows/pipeline-check.yml
+++ b/.github/workflows/pipeline-check.yml
@@ -145,10 +145,13 @@ jobs:
           echo "Active account:"; gcloud auth list --filter=status:ACTIVE
           echo "ADC file: ${GOOGLE_APPLICATION_CREDENTIALS:-<none>}"
           gcloud --version
+
+          # 先用 ADC 取 ID Token；若該子命令不存在或失敗，改用 google-auth 備援
           if IDT="$(gcloud auth application-default print-identity-token --audiences="$BASE" 2>/dev/null)"; then
             :
           else
-            IDT="$(python3 -c 'import os; from google.auth.transport.requests import Request; from google.oauth2.id_token import fetch_id_token; aud=os.environ["BASE"]; print(fetch_id_token(Request(), aud))')"
+            python3 -m pip install --quiet --upgrade google-auth
+            IDT="$(BASE="$BASE" python3 -c 'from google.auth.transport.requests import Request; from google.oauth2.id_token import fetch_id_token; import os; aud = os.environ["BASE"]; print(fetch_id_token(Request(), aud))')"
           fi
           echo "id_token=$IDT" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/vertex-pipeline.yml
+++ b/.github/workflows/vertex-pipeline.yml
@@ -40,12 +40,13 @@ jobs:
         with:
           workload_identity_provider: projects/665759721336/locations/global/workloadIdentityPools/github-pool/providers/github-actions
           service_account: codex-ci@esp32cam-472912.iam.gserviceaccount.com
+          create_credentials_file: true
+          export_environment_variables: true
 
       - name: Setup gcloud SDK
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ env.PROJECT_ID }}
-          export_default_credentials: true
 
       - name: Verify active service account
         run: |
@@ -83,13 +84,14 @@ jobs:
         with:
           workload_identity_provider: projects/665759721336/locations/global/workloadIdentityPools/github-pool/providers/github-actions
           service_account: codex-ci@esp32cam-472912.iam.gserviceaccount.com
+          create_credentials_file: true
+          export_environment_variables: true
 
       - name: Setup gcloud SDK
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ env.PROJECT_ID }}
-          export_default_credentials: true
-          components: beta,alpha
+          install_components: 'beta alpha'
 
       - name: Configure workflow variables
         run: |

--- a/.github/workflows/vertex-pipeline.yml
+++ b/.github/workflows/vertex-pipeline.yml
@@ -91,7 +91,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ env.PROJECT_ID }}
-          install_components: 'beta alpha'
+          install_components: "beta,alpha"
 
       - name: Configure workflow variables
         run: |

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,17 @@
+name: Lint GitHub Workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  actionlint:
+    name: actionlint (validate workflow syntax)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker://rhysd/actionlint:latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.3
+    hooks:
+      - id: actionlint

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@
 
 > **合併前請確認**：GitHub Actions 的 "Lint GitHub Workflows / actionlint (validate workflow syntax)" 工作需成功通過，以確保 workflow 語法正確。
 
+## 貢獻指南
+
+維運須知：
+- 到 Settings → Branches → Branch protection rules（主分支）：
+  - 勾 **Require status checks to pass before merging**
+  - 加入必須通過的檢查：`Lint GitHub Workflows / actionlint (validate workflow syntax)`
+- 儲存設定。
+
 ## 任務說明與驗證指標
 
 | 任務 | 自動化腳本 | 驗證項目 | 對應 log |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@
 2. 執行 `pytest` 驗證任務1~5指標。
 3. 生成測試報告與日誌檔供下載。
 
+> **合併前請確認**：GitHub Actions 的 "Lint GitHub Workflows / actionlint (validate workflow syntax)" 工作需成功通過，以確保 workflow 語法正確。
+
 ## 任務說明與驗證指標
 
 | 任務 | 自動化腳本 | 驗證項目 | 對應 log |


### PR DESCRIPTION
## Summary
- export the ADC credential file path into CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE and GOOGLE_APPLICATION_CREDENTIALS after the OIDC login step
- refresh the gcloud-based Cloud Run ID token step to log the active ADC file and gcloud version before printing the token
- enhance the Cloud Run /health probe to reuse the generated token and emit diagnostics if retries exhaust
- allow the CI workflow to run automatically when pushing to codex/** branches
- add an actionlint workflow and local pre-commit hooks plus README guidance about the new lint requirement
- resolve actionlint errors by indenting diagnostic here-doc bodies and replacing unsupported setup-gcloud inputs with explicit auth steps

## Testing
- actionlint

------
https://chatgpt.com/codex/tasks/task_e_68d5698c9d50832e95c41921385c2898